### PR TITLE
chore(docker): dockerize Flask backend and add MySQL seed init

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Virtualenv
+.venv/
+venv/
+todo-env/
+
+# Local data
+db-data/
+
+# IDE
+.vscode/
+.idea/
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Flask
+FLASK_ENV=development
+SECRET_KEY=dev-secret-key
+
+# DB（compose の db サービスに合わせる）
+DB_USER=todo_user
+DB_PASSWORD=secret
+DB_HOST=db
+DB_PORT=3306
+DB_NAME=todo_app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Python ランタイム（軽量）
+FROM python:3.12-slim
+
+# 便利な環境変数
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# 依存に必要なツール（mysqlclient使わないので最低限でOK）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# 依存インストール
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+# アプリ本体
+COPY . /app
+
+EXPOSE 5000
+
+# backend をパッケージとして起動
+CMD ["python", "-m", "backend.app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -31,4 +31,4 @@ def create_app() -> Flask:
 
 if __name__ == "__main__":
     app = create_app()
-    app.run(host="127.0.0.1", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/db/init/init-db.sql
+++ b/db/init/init-db.sql
@@ -1,0 +1,34 @@
+-- =========================================
+-- init-db.sql (seed only)
+-- このファイルは Docker の MySQL コンテナ初回起動時に
+-- /docker-entrypoint-initdb.d/ 以下の *.sql として自動実行されます。
+-- 役割は「初期データの投入」のみです。
+-- ※ テーブル定義はアプリの ORM / マイグレーションで管理する方針を推奨します。
+-- =========================================
+
+-- DB がない場合に備えて作成（compose側の MYSQL_DATABASE でも作られます）
+CREATE DATABASE IF NOT EXISTS todo_app
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+USE todo_app;
+
+-- ここでは users / todos テーブルが既に存在している前提です。
+-- もし初回にテーブルを SQL で作りたい場合は、CREATE TABLE 文を追加してください。
+
+-- ====== 初期ユーザ投入 ======
+-- password_hash には「ハッシュ値」を入れてください（平文はNG）。
+-- 例）Python で生成: from werkzeug.security import generate_password_hash
+--     print(generate_password_hash("Admin@1234"))
+-- 下の REPLACE_WITH_HASH_* を実際のハッシュ文字列に置き換えてください。
+
+INSERT INTO users (username, password_hash, role)
+VALUES
+  ('admin', 'REPLACE_WITH_HASH_ADMIN', 'admin'),
+  ('user1', 'REPLACE_WITH_HASH_USER1', 'user');
+
+-- ====== 初期ToDo投入（user1に紐づけ例）======
+-- user_id は上で投入したユーザIDに合わせて調整してください。
+INSERT INTO todos (user_id, title, detail, status)
+VALUES
+  (2, '最初のToDo', 'Docker化の動作確認', 0);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: todo-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${DB_NAME:-todo_app}
+      MYSQL_USER: ${DB_USER:-todo_user}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-secret}
+      TZ: Asia/Tokyo
+    ports:
+      - "3307:3306"
+    volumes:
+      # 初回起動時に /docker-entrypoint-initdb.d/*.sql を自動実行
+      - ./db/init:/docker-entrypoint-initdb.d
+      # データ永続化
+      - ./db-data:/var/lib/mysql
+
+  backend:
+    build: .
+    container_name: todo-backend
+    depends_on:
+      - db
+    ports:
+      - "8000:5000"
+    env_file:
+      - .env        # アプリ用の環境変数
+    environment:
+      TZ: Asia/Tokyo
+    # 開発時のホットリロード用途（任意）
+    volumes:
+      - .:/app


### PR DESCRIPTION
## チケットURL（イシュー）
#4 , #6 

## 変更内容（追加）
アプリのローカルデプロイ→Docker化に伴う修正
- init-db.sqlの内容修正
- app.pyについて Docker起動に合わせて起動時のホストを修正
- Dockerfileの作成
- docker-compose.ymlの修正
- .env.exampleの作成

## レビューで確認してほしい点
- [ ] ベースイメージの確認
- [ ] .dockerignoreが適切かどうか
- [ ] Dockerfileの記載内容
- [ ] docker-compose.ymlの記載内容

## 今回のレビュには含めない
- app.pyのレビュー
- MySQLへの接続確認（ビルドは確認済み）
- フロントエンドの操作確認　#4 #6 実施後に #5 を実施予定。

## 実施済みセルフレビュー
- Linterによるエラー確認
- イシューチケットに作業ログを追記した
- 実装ガイドライン（イシュー）に沿って、開発していることを確認した
- ローカル環境でdockerの起動を確認し、バックエンドの疎通が取れていることを確認した
Curlで/healthに対してリクエストし、期待するレスポンスを得ることができた。